### PR TITLE
Add workflow to submit iOS build with EAS

### DIFF
--- a/.github/workflows/eas-submit-ios.yml
+++ b/.github/workflows/eas-submit-ios.yml
@@ -1,0 +1,30 @@
+name: EAS Submit Only
+
+on:
+  workflow_dispatch:
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Submit latest iOS build to TestFlight
+        env:
+          EAS_ACCESS_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          ASC_API_KEY_PATH: ./authkey.p8
+          ASC_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+        run: |
+          eas submit --platform ios --profile production --non-interactive --latest
+


### PR DESCRIPTION
## Summary
- add `eas-submit-ios` workflow for manually submitting the latest build to TestFlight

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685cdfdf53208333927e971e44844408