### PR TITLE
Update Expo secret key names

### DIFF
--- a/.github/workflows/eas-build-ios.yml
+++ b/.github/workflows/eas-build-ios.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm install -g eas-cli
 
       - name: 🔑 Set Expo Access Token
-        run: echo "EXPO_TOKEN=${{ secrets.EXPO_TOKEN }}" >> $GITHUB_ENV
+        run: echo "EXPO_TOKEN=${{ secrets.EXPO_ACCESS_TOKEN }}" >> $GITHUB_ENV
 
       - name: 📚 Install Dependencies
         run: npm ci
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "url=$(eas build:list --platform ios --status finished --limit 1 --json | jq -r '.[0].artifacts.buildUrl')" >> $GITHUB_OUTPUT
         env:
-          EAS_ACCESS_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EAS_ACCESS_TOKEN: ${{ secrets.EXPO_ACCESS_TOKEN }}
 
       - name: 🧾 Save App Store API Key (.p8)
         run: |
@@ -51,5 +51,5 @@ jobs:
             --asc-api-key-issuer-id ${{ secrets.ASC_API_KEY_ISSUER_ID }} \
             --asc-api-key-id ${{ secrets.ASC_API_KEY_ID }}
         env:
-          EAS_ACCESS_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EAS_ACCESS_TOKEN: ${{ secrets.EXPO_ACCESS_TOKEN }}
 

--- a/.github/workflows/eas-submit-ios.yml
+++ b/.github/workflows/eas-submit-ios.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Submit latest iOS build to TestFlight
         env:
-          EAS_ACCESS_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EAS_ACCESS_TOKEN: ${{ secrets.EXPO_ACCESS_TOKEN }}
           ASC_API_KEY_PATH: ./authkey.p8
           ASC_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
           ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}


### PR DESCRIPTION
## Summary
- update workflows to use `EXPO_ACCESS_TOKEN` secret

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_685d123588cc8333962a0f3a829675c8